### PR TITLE
Add internal link to conversation headers

### DIFF
--- a/importer/dates.py
+++ b/importer/dates.py
@@ -1,10 +1,8 @@
-from datetime import datetime
-
-import pytz
+from datetime import datetime, timezone
 
 
 def epoch_to_dt(epoch_time: float) -> datetime:
-    return datetime.fromtimestamp(epoch_time, tz=pytz.UTC)
+    return datetime.fromtimestamp(epoch_time, tz=timezone.utc)
 
 def epoch_to_date(epoch_time: float) -> str:
     dt: datetime = epoch_to_dt(epoch_time)

--- a/importer/extract.py
+++ b/importer/extract.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from pathlib import Path
 
-import pytz
-
 from importer.dates import epoch_to_dt
 from importer.graph import find_latest_conversation_turn, resolve_message_chain_from_latest
 
@@ -34,7 +32,9 @@ def construct_header_for_turn(turn: dict[str, any]) -> str:
         label = "User"
     else:
         label = message.get("metadata", {}).get("model_slug", "System")
-    return f"# {label} ({date_str})"
+    turn_id: str | None = turn.get("id")
+    suffix: str = f" ^{turn_id}" if turn_id else ""
+    return f"# {label} ({date_str}){suffix}"
 
 def extract_turn_as_markdown(turn: dict[str, any]) -> str | None:
     body: str = extract_text_from_turn(turn)

--- a/tests/extract/test_construct_header_from_turn.py
+++ b/tests/extract/test_construct_header_from_turn.py
@@ -7,6 +7,7 @@ class TestConstructHeaderFromTurn:
     @patch("importer.dates.epoch_to_human_timestamp", return_value="Monday, December 7, 2001 14:32:27 UTC")
     def test_labels_as_user_when_user(self, mock_epoch: Any) -> None:
         turn = {
+            "id": "turn-1",
             "message": {
                 "author": {
                     "role": "user"
@@ -15,11 +16,12 @@ class TestConstructHeaderFromTurn:
             }
         }
         header = construct_header_for_turn(turn)
-        assert header == "# User (Monday, December 7, 2001 14:32:27 UTC)"
+        assert header == "# User (Monday, December 7, 2001 14:32:27 UTC) ^turn-1"
 
     @patch("importer.dates.epoch_to_human_timestamp", return_value="Monday, December 7, 2001 14:32:27 UTC")
     def test_labels_with_model_name_when_system(self, mock_epoch: Any) -> None:
         turn = {
+            "id": "turn-2",
             "message": {
                 "author": {
                     "role": "assistant"
@@ -31,4 +33,15 @@ class TestConstructHeaderFromTurn:
             }
         }
         header = construct_header_for_turn(turn)
-        assert header == "# GPT-4o (Monday, December 7, 2001 14:32:27 UTC)"
+        assert header == "# GPT-4o (Monday, December 7, 2001 14:32:27 UTC) ^turn-2"
+
+    def test_omits_internal_link_when_id_missing(self) -> None:
+        with patch("importer.dates.epoch_to_human_timestamp", return_value="Thursday"):
+            turn = {
+                "message": {
+                    "author": {"role": "user"},
+                    "create_time": 1
+                }
+            }
+            header = construct_header_for_turn(turn)
+            assert header == "# User (Thursday)"

--- a/tests/extract/test_extract_conversation_body.py
+++ b/tests/extract/test_extract_conversation_body.py
@@ -4,6 +4,7 @@ def test_extract_conversation_body_selects_latest_branch_and_assembles_message_c
     conversation: dict[str, any] = {
         "mapping": {
             "node1": {
+                "id": "node1",
                 "children": ["node2", "node3"],
                 "parent": None,
                 "message": {
@@ -13,6 +14,7 @@ def test_extract_conversation_body_selects_latest_branch_and_assembles_message_c
                 }
             },
             "node2": {
+                "id": "node2",
                 "children": [],
                 "parent": "node1",
                 "message": {
@@ -29,6 +31,7 @@ def test_extract_conversation_body_selects_latest_branch_and_assembles_message_c
                 }
             },
             "node3": {
+                "id": "node3",
                 "children": ["node4"],
                 "parent": "node1",
                 "message": {
@@ -38,6 +41,7 @@ def test_extract_conversation_body_selects_latest_branch_and_assembles_message_c
                 }
             },
             "node4": {
+                "id": "node4",
                 "children": [],
                 "parent": "node3",
                 "message": {
@@ -49,9 +53,9 @@ def test_extract_conversation_body_selects_latest_branch_and_assembles_message_c
         }
     }
     expected: str = (
-        "# User (Thursday, January 1, 1970 00:00:50 UTC)\n\n"
+        "# User (Thursday, January 1, 1970 00:00:50 UTC) ^node1\n\n"
         "Root message\n\n"
-        "# GPT-4o (Thursday, January 1, 1970 00:02:30 UTC)\n\n"
+        "# GPT-4o (Thursday, January 1, 1970 00:02:30 UTC) ^node2\n\n"
         "First part | Second part"
     )
     result: str = extract_conversation_body(conversation)

--- a/tests/extract/test_extract_turn_as_markdown.py
+++ b/tests/extract/test_extract_turn_as_markdown.py
@@ -6,16 +6,16 @@ class TestExtractTurnFromMarkdown:
     @patch("importer.extract.extract_text_from_turn")
     @patch("importer.extract.construct_header_for_turn")
     def test_returns_header_and_body_when_delegates_return_values(self, mock_construct_header: Any, mock_extract_text: Any) -> None:
-        mock_construct_header.return_value = "# User (Wed, 2025-04-09 14:37:52)"
+        mock_construct_header.return_value = "# User (Wed, 2025-04-09 14:37:52) ^turn-1"
         mock_extract_text.return_value = "Turn message"
         turn = {"dummy": "data"}
         result = extract_turn_as_markdown(turn)
-        assert result == "# User (Wed, 2025-04-09 14:37:52)\n\nTurn message"
+        assert result == "# User (Wed, 2025-04-09 14:37:52) ^turn-1\n\nTurn message"
 
     @patch("importer.extract.extract_text_from_turn")
     @patch("importer.extract.construct_header_for_turn")
     def test_returns_none_when_body_is_missing(self, mock_construct_header: Any, mock_extract_text: Any) -> None:
-        mock_construct_header.return_value = "# User (Wed, 2025-04-09 14:37:52)"
+        mock_construct_header.return_value = "# User (Wed, 2025-04-09 14:37:52) ^turn-1"
         mock_extract_text.return_value = None
         turn = {"dummy": "data"}
         result = extract_turn_as_markdown(turn)


### PR DESCRIPTION
## Summary
- use `timezone.utc` for date conversion
- add internal link to headings when `id` is present
- add optional id handling tests
- update conversation body fixture with ids
- update tests for new header format

## Testing
- `pytest -q`